### PR TITLE
fix: mobile navigation menu

### DIFF
--- a/src/components/navigation/mobile/Menu.tsx
+++ b/src/components/navigation/mobile/Menu.tsx
@@ -12,7 +12,7 @@ const Wrapper = styled.div<{
   $visible: boolean;
 }>`
   position: fixed;
-  top: calc(var(--nav-height) + var(--banner-nav-offset-height));
+  top: calc(var(--nav-height) + var(--banner-nav-offset-height, 0px));
   bottom: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
Mobile navigation menu is broken

<img width="1037" alt="Знімок екрана 2024-06-26 о 14 37 25" src="https://github.com/near/nearorg/assets/34593263/09ee9a3d-750b-476b-89ae-49ec7f3c6500">

This happened because mobile menu position relies on `--banner-nav-offset-height` variable  https://github.com/near/nearorg/blob/develop/src/components/navigation/mobile/Menu.tsx#L15. That variable is undefined and get it's value from [here](https://github.com/near/nearorg/blob/develop/src/components/Banner.tsx#L78) which means we need to set a default value for `--banner-nav-offset-height`. And that all this PR is about 🙂