### PR TITLE
fix: near events list

### DIFF
--- a/src/hooks/useLatestEvents.ts
+++ b/src/hooks/useLatestEvents.ts
@@ -14,6 +14,8 @@ export type MappedEvent = {
 // TODO: Refactor this hook to use something like ReactQuery
 
 export function useLatestEvents(limit = 3) {
+  // TODO: Refactor this hook to use it for ai events too
+  const aiEventsUrl = 'https://lu.ma';
   const [events, setEvents] = useState<MappedEvent[]>([]);
   const [hasMoreEvents, setHasMoreEvents] = useState(false);
 
@@ -30,10 +32,10 @@ export function useLatestEvents(limit = 3) {
           return {
             date: formatDate(item.event.start_at, item.event.end_at),
             description: item.event.description,
-            location: formatLocation(item.event.geo_address_json),
+            location: formatLocation(item.event.geo_address_json ?? item.event.geo_address_info),
             thumbnail: item.event.cover_url,
             title: item.event.name,
-            url: item.event.url,
+            url: `${aiEventsUrl}/${item.event.url}`,
           };
         });
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,2 +1,0 @@
-export const eventsApiUrl = process.env.NEXT_PUBLIC_EVENTS_API_URL;
-export const eventsApiKey = process.env.NEXT_PUBLIC_EVENTS_API_KEY;

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,5 +1,3 @@
-import { eventsApiKey, eventsApiUrl } from './config';
-
 export type EventItem = {
   api_id: string;
   event: {
@@ -11,6 +9,7 @@ export type EventItem = {
     cover_url: string;
     url: string;
     geo_address_json: any;
+    geo_address_info?: any;
   };
 };
 
@@ -20,20 +19,16 @@ type EventsListData = {
 };
 
 export const fetchEvents = async (limit: number, offset: number): Promise<EventsListData> => {
-  const currentDate = new Date();
-  currentDate.setDate(currentDate.getDate() - 1);
-  const afterDate = currentDate.toISOString().split('T')[0]; // YYYY-MM-DD
-
-  const queryFrom = `after=${afterDate}`;
+  const eventsApiUrl = 'https://api.lu.ma';
+  const queryFrom = `period=future`;
   const queryLimit = `pagination_limit=${limit ?? 10}`;
   const queryOffset = offset ? `pagination_offset=${offset}` : '';
   const queryParams = [queryFrom, queryLimit, queryOffset].filter(Boolean).join('&');
 
-  const res = await fetch(`${eventsApiUrl}/calendar/list-events?${queryParams}`, {
+  const res = await fetch(`${eventsApiUrl}/calendar/get-items?calendar_api_id=cal-Nrz4EsmLDjXvjPp&${queryParams}`, {
     method: 'GET',
     headers: {
       accept: 'application/json',
-      'x-luma-api-key': eventsApiKey as string,
     },
   });
 


### PR DESCRIPTION
For some reason, using the public API url returns exact the same list of events as https://lu.ma/NEAR-community has. That's why, I decided to go the way I did it for `/ai` page.

Closes https://github.com/near/near-discovery/issues/1215