### PR TITLE
сhore: change events show limit

### DIFF
--- a/src/components/pages/Ai.tsx
+++ b/src/components/pages/Ai.tsx
@@ -213,7 +213,7 @@ const getInvolvedItems = [
 ];
 
 export const Ai = () => {
-  const { events } = useEvents(LUMA_NEAR_AI_CALENDAR_ID);
+  const { events, hasMoreEvents } = useEvents(LUMA_NEAR_AI_CALENDAR_ID);
   return (
     <Wrapper>
       <AiSection $backgroundColor="#9797FF">
@@ -327,9 +327,20 @@ export const Ai = () => {
       </Section>
 
       <Section $backgroundColor="var(--violet6)">
-        <Container>
+        <Container $gap="48px">
           <Flex $direction="column" $gap="24px">
-            <H2>Upcoming NEAR AI Events</H2>
+            <Flex $alignItems="center" $justifyContent="space-between">
+              <H2>Upcoming NEAR AI Events</H2>
+              {hasMoreEvents && (
+                <Button
+                  href="https://lu.ma/edgeAGI"
+                  target="_blank"
+                  label="View All"
+                  variant="secondary"
+                  size="small"
+                />
+              )}
+            </Flex>
             <Text $size="text-2xl" $mobileSize="text-l" style={{ maxWidth: '808px' }}>
               Join us at conferences, meetups, and more as we gather across the globe to discuss the future of
               User-Owned AI.

--- a/src/components/pages/Events.tsx
+++ b/src/components/pages/Events.tsx
@@ -198,7 +198,7 @@ export const Events = () => {
               )}
             </Flex>
 
-            <Grid $columns="1fr 1fr 1fr" $gap="20px">
+            <Grid $columns="1fr 1fr 1fr" $gap="24px">
               {otherEvents.map((event) => {
                 return (
                   <Article key={event.title} href={event.url} target="_blank" style={{ minWidth: 0 }}>

--- a/src/components/pages/Events.tsx
+++ b/src/components/pages/Events.tsx
@@ -108,7 +108,7 @@ const CoverCardImageWrapper = styled.div`
 `;
 
 export const Events = () => {
-  const { events, hasMoreEvents } = useEvents(LUMA_NEAR_CALENDAR_ID, 4);
+  const { events, hasMoreEvents } = useEvents(LUMA_NEAR_CALENDAR_ID, 7);
   const featuredEvent = events[0] as MappedEvent | undefined;
   const otherEvents = events.filter((event) => event.title !== featuredEvent?.title);
 


### PR DESCRIPTION
This PR increases limit for near events. Home page still displays 3 events (no change here), but 6 on `/events` page Also, added a `View All` button to /ai page to be able to navigate to all ai specific events