### PR TITLE
feat: add hzn calendar events to `ai` page

### DIFF
--- a/src/components/pages/Ai.tsx
+++ b/src/components/pages/Ai.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { useEvents } from '@/hooks/useEvents';
 import { NEAR_AI_URL } from '@/utils/constants';
-import { LUMA_NEAR_AI_CALENDAR_ID } from '@/utils/constants';
+import { LUMA_NEAR_AI_CALENDAR_ID, LUMA_NEAR_HZN_CALENDAR_ID } from '@/utils/constants';
 
 import { Article, ArticleImage } from '../lib/Article';
 import { Button } from '../lib/Button';
@@ -231,7 +231,7 @@ const getInvolvedItems = [
 ];
 
 export const Ai = () => {
-  const { events, hasMoreEvents } = useEvents(LUMA_NEAR_AI_CALENDAR_ID);
+  const { events, hasMoreEvents } = useEvents([LUMA_NEAR_AI_CALENDAR_ID, LUMA_NEAR_HZN_CALENDAR_ID]);
   return (
     <Wrapper>
       <AiSection $backgroundColor="#9797FF">

--- a/src/components/pages/Events.tsx
+++ b/src/components/pages/Events.tsx
@@ -108,7 +108,7 @@ const CoverCardImageWrapper = styled.div`
 `;
 
 export const Events = () => {
-  const { events, hasMoreEvents } = useEvents(LUMA_NEAR_CALENDAR_ID, 7);
+  const { events, hasMoreEvents } = useEvents([LUMA_NEAR_CALENDAR_ID], 7);
   const featuredEvent = events[0] as MappedEvent | undefined;
   const otherEvents = events.filter((event) => event.title !== featuredEvent?.title);
 

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -294,7 +294,7 @@ function returnImageSrc(cfid: string) {
 
 export const Home = () => {
   const { statistics } = useStatistics();
-  const { events } = useEvents(LUMA_NEAR_CALENDAR_ID);
+  const { events } = useEvents([LUMA_NEAR_CALENDAR_ID]);
   const { news } = useLatestNews();
 
   return (

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,3 +2,4 @@ export const CREATE_ACCOUNT_URL = '/signup';
 export const NEAR_AI_URL = 'https://near.ai';
 export const LUMA_NEAR_CALENDAR_ID = 'cal-Nrz4EsmLDjXvjPp';
 export const LUMA_NEAR_AI_CALENDAR_ID = 'cal-dzvTEx2EC4F2tk8';
+export const LUMA_NEAR_HZN_CALENDAR_ID = 'cal-BOILOqC74o135WB';


### PR DESCRIPTION
This PR adds horizon events to `/ai` page. To accomplish this, I changed our `useEvent` to accept and array of `calendarApiIds` instead of single `calendarApiId`.

Closes https://github.com/near/near-discovery/issues/1229