### PR TITLE
fix: short links accessibility

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -184,6 +184,11 @@ const nextConfig = {
         destination: 'https://airtable.com/appr1nBRRGx2PTJVh/shrpa99vKKW3xafso',
         permanent: false,
       },
+      {
+        source: '/s/:path*',
+        destination: `${appGatewayHostname}/s/:path*`,
+        permanent: true,
+      },
     ];
   },
   rewrites: async () => [


### PR DESCRIPTION
After splitting near.org into two repositories dev.near.org & near.org we forgot to configure redirect for short links (see the linked issue). This PR solves it.

Closes https://github.com/near/near-discovery/issues/1242