### PR TITLE
Get blog content direct from pages.near.org

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -192,10 +192,6 @@ const nextConfig = {
       source: '/api/analytics/:path*',
       destination: 'https://near.dataplane.rudderstack.com/:path*',
     },
-    {
-      source: '/blog/:path*',
-      destination: '/blog/:path*/index.html',
-    },
   ],
   headers: async () => [
     {

--- a/src/components/RedactedBanner.tsx
+++ b/src/components/RedactedBanner.tsx
@@ -17,7 +17,6 @@ export const RedactedBanner = () => {
             src="/images/redacted/redacted_live-now-banner.png"
             alt="Redacted: Reclaim your sovereignty at no cost. Click to be there IRL"
           />
-          
         </a>
       </div>
     </Container>

--- a/src/components/navigation/categories.ts
+++ b/src/components/navigation/categories.ts
@@ -41,7 +41,6 @@ export const navigationCategories = [
             url: '/data-availability',
             icon: 'ph-database ph-bold',
           },
-          
         ],
       },
     ],

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -186,8 +186,6 @@ export const Home = () => {
               The Blockchain for AI
             </Text>
 
-            
-
             <Flex>
               <Button
                 href="https://docs.near.org"

--- a/src/components/pages/Intents.tsx
+++ b/src/components/pages/Intents.tsx
@@ -1,188 +1,187 @@
-import { Article, Button, Flex, Grid, Card, Pattern, Section, Text, IconCircle } from '@near-pagoda/ui';
+import { Article, Button, Card, Flex, Grid, IconCircle, Pattern, Section, Text } from '@near-pagoda/ui';
+import Image from 'next/image';
+
 import type { MappedEvent } from '@/hooks/useEvents';
 import { useEvents } from '@/hooks/useEvents';
 import { LUMA_NEAR_CALENDAR_ID } from '@/utils/constants';
-import Image from 'next/image';
 //import s from './Intents.module.scss';
 
 export const Intents = () => {
-    const { events, hasMoreEvents } = useEvents([LUMA_NEAR_CALENDAR_ID], 7);
-    const featuredEvent = events[0] as MappedEvent | undefined;
-    const otherEvents = events.filter((event) => event.title !== featuredEvent?.title);
+  const { events, hasMoreEvents } = useEvents([LUMA_NEAR_CALENDAR_ID], 7);
+  const featuredEvent = events[0] as MappedEvent | undefined;
+  const otherEvents = events.filter((event) => event.title !== featuredEvent?.title);
 
-    const whyBuildWithIntents = [
-        {
-            name: 'New possibilities and use cases',
-            description: 'Explore net-new primitives when you combine any intent type with the power of AI agents. Go beyond swaps and reimagine a new type of trading, auction, token and much more. With NEAR Intents, AI assistants can direct other AI agents to take actions for end users, truly combining the powers of AI and the blockchain.',
-            icon: 'images/intents/lightbulb.svg',
-        
-            target: '_blank',
-          },
-        {
-          name: 'Secure handling of any form of asset',
-          description:
-            'Transfer, stake, and manage a wide range of assets, including NFTs, FTs, SBTs, non-transferable assets, or any other form of value on any chain with security and compliance in mind.',
-          icon: 'images/intents/secure.svg',
-    
-          target: '_blank',
-        },
-        {
-          name: 'Open and permissionless',
-          description:
-            'Decentralized, cross-chain infrastructure lets you build or launch your own solver or new financial products easily.',
-          icon: 'images/intents/open.svg',
-        
-          target: '_blank',
-        },
-        {
-            name: 'Reliable, fast and smooth experience',
-            description:
-              'Cross-chain settlement between agents and users happens in seconds, regardless of the native asset chain. Sharded smart contracts and dynamic resharding ensure reliable handling of trillions of agent transactions',
-            icon: 'images/intents/shield.svg',
-          
-            target: '_blank',
-          },
-          {
-            name: 'Combined liquidity all in one place',
-            description:
-              'Bridging the gap between DEXs across chains, CEXs, and even outside crypto ensures protocol developers, distribution channels, solvers, ecosystems, or token founders can all participate and innovate',
-            icon: 'images/intents/money.svg',
-           
-            target: '_blank',
-          },
-      ];
+  const whyBuildWithIntents = [
+    {
+      name: 'New possibilities and use cases',
+      description:
+        'Explore net-new primitives when you combine any intent type with the power of AI agents. Go beyond swaps and reimagine a new type of trading, auction, token and much more. With NEAR Intents, AI assistants can direct other AI agents to take actions for end users, truly combining the powers of AI and the blockchain.',
+      icon: 'images/intents/lightbulb.svg',
 
-      const exploreIntents = [
-        {
-          name: 'Bitte',
-          description:
-            "Smart accounts with on-chain AI.",
-          icon: '/images/intents/bitte.svg',
-          url: 'https://bitte.ai',
-          target: '_blank',
-        },
-        {
-          name: 'REF Finance',
-          description:
-            'The leading DEX on NEAR',
-          icon: '/images/intents/ref.png',
-          url: 'https://ref.finance',
-          target: '_blank',
-        },
-        {
-          name: 'Burrow Cash',
-          description: 'Decentralized lending and borrowing protocol on NEAR',
-          icon: '/images/intents/burrows.svg',
-          url: 'https://burrow.finance/',
-          target: '_blank',
-        },
-        {
-          name: 'Infinex (Coming Soon)',
-          description:
-            'Decentralized exchange platform with seamless, multichain UX and the safest way to get on-chain.',
-          icon: '/images/intents/infinex.svg',
-          url: 'https://infinex.xyz/',
-          target: '_blank',
-        },
-        {
-          name: 'Frax Finance (Coming Soon)',
-          description: 'The world’s most innovative decentralized stablecoins and DeFi stablecoin infrastructure',
-          icon: '/images/intents/frax.png',
-          url: 'https://frax.finance/',
-          target: '_blank',
-        },
-        {
-          name: 'Omnilane',
-          description: 'Cross-chain RFQ (request-for-quote) protocol',
-          icon: '/images/intents/omnilane.png',
-          url: 'https://omnilane.xyz/',
-          target: '_blank',
-        },
-        {
-          name: 'Atlas Protocol',
-          description: 'Bitcoin liquid staking',
-          icon: '/images/intents/atlas.png',
-          url: 'https://atlasprotocol.com/',
-          target: '_blank',
-        },
-        {
-          name: 'Templar Protocol',
-          description: 'Chain abstracted money market',
-          icon: '/images/intents/templar.svg',
-          url: 'https://linktr.ee/templarfi',
-          target: '_blank',
-        },
-        {
-          name: 'Covenant Finance',
-          description: 'Perpetual debt and fixed income products',
-          icon: '/images/intents/covenant.png',
-          url: 'https://covenant.finance/',
-          target: '_blank',
-        },
-        {
-          name: 'Thunderhood',
-          description: 'Leverage trading for memecoins',
-          icon: '/images/intents/thunderhood.png',
-          url: 'https://testnet.thunderhood.com/home',
-          target: '_blank',
-        },
-        {
-          name: 'Delta Trade',
-          description: 'Grid trading bot on Telegram',
-          icon: '/images/intents/delta.png',
-          url: 'https://deltatrade.ai',
-          target: '_blank',
-        },
-        {
-          name: 'Allstake',
-          description: 'Multi-asset re-staking',
-          icon: '/images/intents/allstake.png',
-          url: 'https://allstake.io/',
-          target: '_blank',
-        },
-        {
-          name: 'Kairo Money',
-          description: 'Lending protocol',
-          icon: '/images/intents/kairo.png',
-          url: '#',
-          target: '_blank',
-        },
-        {
-          name: 'Vita Finance',
-          description: 'Automated market maker',
-          icon: '/images/intents/vita.png',
-          url: '#',
-          target: '_blank',
-        },
-        {
-          name: 'BitHive',
-          description: 'Bitcoin staking with unparalleled security',
-          icon: '/images/intents/bithive.svg',
-          url: 'https://bithive.fi/',
-          target: '_blank',
-        },
-      ];
+      target: '_blank',
+    },
+    {
+      name: 'Secure handling of any form of asset',
+      description:
+        'Transfer, stake, and manage a wide range of assets, including NFTs, FTs, SBTs, non-transferable assets, or any other form of value on any chain with security and compliance in mind.',
+      icon: 'images/intents/secure.svg',
 
-    const Roadmap = [
-        {
-          name: 'NOV 2024',
-          description: 'Beta rollout, with support for NEAR, Aurora, Ethereum, and Bitcoin',
-         
-          url: '/near/widget/ComponentDetailsPage?src=hack.near/widget/widgets.rank',
-        },
-        {
-          name: 'JAN 2025',
-          description: 'Main launch, with support for NEAR, Aurora, Ethereum, Bitcoin, Solana, Arbitrum, Base, TON',
-      
-          url: '/near/widget/ComponentDetailsPage?src=ndcplug.near/widget/BOSHACKS.Index',
-        },
-        {
-          name: '2025',
-          description: 'Additional intents supported, including AccountFi',
+      target: '_blank',
+    },
+    {
+      name: 'Open and permissionless',
+      description:
+        'Decentralized, cross-chain infrastructure lets you build or launch your own solver or new financial products easily.',
+      icon: 'images/intents/open.svg',
 
-          url: '/near/widget/ComponentDetailsPage?src=nearui.near/widget/index',
-        },
-      ];
+      target: '_blank',
+    },
+    {
+      name: 'Reliable, fast and smooth experience',
+      description:
+        'Cross-chain settlement between agents and users happens in seconds, regardless of the native asset chain. Sharded smart contracts and dynamic resharding ensure reliable handling of trillions of agent transactions',
+      icon: 'images/intents/shield.svg',
+
+      target: '_blank',
+    },
+    {
+      name: 'Combined liquidity all in one place',
+      description:
+        'Bridging the gap between DEXs across chains, CEXs, and even outside crypto ensures protocol developers, distribution channels, solvers, ecosystems, or token founders can all participate and innovate',
+      icon: 'images/intents/money.svg',
+
+      target: '_blank',
+    },
+  ];
+
+  const exploreIntents = [
+    {
+      name: 'Bitte',
+      description: 'Smart accounts with on-chain AI.',
+      icon: '/images/intents/bitte.svg',
+      url: 'https://bitte.ai',
+      target: '_blank',
+    },
+    {
+      name: 'REF Finance',
+      description: 'The leading DEX on NEAR',
+      icon: '/images/intents/ref.png',
+      url: 'https://ref.finance',
+      target: '_blank',
+    },
+    {
+      name: 'Burrow Cash',
+      description: 'Decentralized lending and borrowing protocol on NEAR',
+      icon: '/images/intents/burrows.svg',
+      url: 'https://burrow.finance/',
+      target: '_blank',
+    },
+    {
+      name: 'Infinex (Coming Soon)',
+      description: 'Decentralized exchange platform with seamless, multichain UX and the safest way to get on-chain.',
+      icon: '/images/intents/infinex.svg',
+      url: 'https://infinex.xyz/',
+      target: '_blank',
+    },
+    {
+      name: 'Frax Finance (Coming Soon)',
+      description: 'The world’s most innovative decentralized stablecoins and DeFi stablecoin infrastructure',
+      icon: '/images/intents/frax.png',
+      url: 'https://frax.finance/',
+      target: '_blank',
+    },
+    {
+      name: 'Omnilane',
+      description: 'Cross-chain RFQ (request-for-quote) protocol',
+      icon: '/images/intents/omnilane.png',
+      url: 'https://omnilane.xyz/',
+      target: '_blank',
+    },
+    {
+      name: 'Atlas Protocol',
+      description: 'Bitcoin liquid staking',
+      icon: '/images/intents/atlas.png',
+      url: 'https://atlasprotocol.com/',
+      target: '_blank',
+    },
+    {
+      name: 'Templar Protocol',
+      description: 'Chain abstracted money market',
+      icon: '/images/intents/templar.svg',
+      url: 'https://linktr.ee/templarfi',
+      target: '_blank',
+    },
+    {
+      name: 'Covenant Finance',
+      description: 'Perpetual debt and fixed income products',
+      icon: '/images/intents/covenant.png',
+      url: 'https://covenant.finance/',
+      target: '_blank',
+    },
+    {
+      name: 'Thunderhood',
+      description: 'Leverage trading for memecoins',
+      icon: '/images/intents/thunderhood.png',
+      url: 'https://testnet.thunderhood.com/home',
+      target: '_blank',
+    },
+    {
+      name: 'Delta Trade',
+      description: 'Grid trading bot on Telegram',
+      icon: '/images/intents/delta.png',
+      url: 'https://deltatrade.ai',
+      target: '_blank',
+    },
+    {
+      name: 'Allstake',
+      description: 'Multi-asset re-staking',
+      icon: '/images/intents/allstake.png',
+      url: 'https://allstake.io/',
+      target: '_blank',
+    },
+    {
+      name: 'Kairo Money',
+      description: 'Lending protocol',
+      icon: '/images/intents/kairo.png',
+      url: '#',
+      target: '_blank',
+    },
+    {
+      name: 'Vita Finance',
+      description: 'Automated market maker',
+      icon: '/images/intents/vita.png',
+      url: '#',
+      target: '_blank',
+    },
+    {
+      name: 'BitHive',
+      description: 'Bitcoin staking with unparalleled security',
+      icon: '/images/intents/bithive.svg',
+      url: 'https://bithive.fi/',
+      target: '_blank',
+    },
+  ];
+
+  const Roadmap = [
+    {
+      name: 'NOV 2024',
+      description: 'Beta rollout, with support for NEAR, Aurora, Ethereum, and Bitcoin',
+
+      url: '/near/widget/ComponentDetailsPage?src=hack.near/widget/widgets.rank',
+    },
+    {
+      name: 'JAN 2025',
+      description: 'Main launch, with support for NEAR, Aurora, Ethereum, Bitcoin, Solana, Arbitrum, Base, TON',
+
+      url: '/near/widget/ComponentDetailsPage?src=ndcplug.near/widget/BOSHACKS.Index',
+    },
+    {
+      name: '2025',
+      description: 'Additional intents supported, including AccountFi',
+
+      url: '/near/widget/ComponentDetailsPage?src=nearui.near/widget/index',
+    },
+  ];
 
   return (
     <>
@@ -190,56 +189,46 @@ export const Intents = () => {
         <Pattern>
           <Flex gap="l" stack align="center">
             <Text as="h1" size="text-hero-l">
-            Intents are NEAR 
+              Intents are NEAR
             </Text>
 
             <Text size="text-l" weight={400}>
-            Powering a new era of transactions between AI and the real world.
+              Powering a new era of transactions between AI and the real world.
             </Text>
 
             <Flex gap="l" wrap align="center" justify="center">
-              <Button
-                href="#explore"
-                label="Explore Intents"
-                variant="secondary"
-                fill="outline"
-                size="large"
-              />
+              <Button href="#explore" label="Explore Intents" variant="secondary" fill="outline" size="large" />
 
-              <Button
-                href="#getstarted"
-                label="Get Started"
-                variant="primary"
-                size="large"
-              />
-
-              
+              <Button href="#getstarted" label="Get Started" variant="primary" size="large" />
             </Flex>
           </Flex>
         </Pattern>
       </Section>
-      <Section gap="2xl" padding="hero" background="black" >
+      <Section gap="2xl" padding="hero" background="black">
         <Card
           background="green-brand"
           padding="l"
           style={{ maxWidth: '1200px', margin: '0 auto', marginTop: '-200px', borderRadius: '50px' }}
         >
           <Flex stack gap="xl">
-          <Text as="h2" size="text-hero-m" color="black">
-          NEAR Intents are now available as part of the NEAR Protocol.
-          </Text>
-          <Text size="text-2xl" weight={400} color="black">
-            NEAR Intents are a new type of transaction that allow information, requests, assets, and actions to be exchanged between AI agents, services, and end users.
-          </Text>
-            
-            <div style={{ 
-              width: '100%',
-              aspectRatio: '16/9',
-              backgroundColor: '#000000',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center'
-            }}>
+            <Text as="h2" size="text-hero-m" color="black">
+              NEAR Intents are now available as part of the NEAR Protocol.
+            </Text>
+            <Text size="text-2xl" weight={400} color="black">
+              NEAR Intents are a new type of transaction that allow information, requests, assets, and actions to be
+              exchanged between AI agents, services, and end users.
+            </Text>
+
+            <div
+              style={{
+                width: '100%',
+                aspectRatio: '16/9',
+                backgroundColor: '#000000',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
               <video
                 autoPlay
                 muted
@@ -262,31 +251,23 @@ export const Intents = () => {
               Why Build with Intents?
             </Text>
             <Text size="text-2xl" weight={400} color="white">
-              Finally, tech that not only unifies liquidity but also brings AI participants together with financial services, commerce, and end users in the real world.
+              Finally, tech that not only unifies liquidity but also brings AI participants together with financial
+              services, commerce, and end users in the real world.
             </Text>
           </Flex>
 
           <Grid columns="1fr 1fr 1fr" columnsTablet="1fr 1fr" columnsPhone="1fr" gap="l">
             {whyBuildWithIntents.map((item) => (
-              <Card
-                border="black"
-                background="black"
-                gap="l"
-                padding="l"
-                key={item.name}
-              >
-                    <Image 
-                      src={item.icon}
-                      alt="Article icon"
-                      width={24}
-                      height={24} 
-                      />
+              <Card border="black" background="black" gap="l" padding="l" key={item.name}>
+                <Image src={item.icon} alt="Article icon" width={24} height={24} />
 
                 <Flex stack>
                   <Text size="text-l" weight="500" color="white">
                     {item.name}
                   </Text>
-                  <Text size="text-s" color="white">{item.description}</Text>
+                  <Text size="text-s" color="white">
+                    {item.description}
+                  </Text>
                 </Flex>
               </Card>
             ))}
@@ -299,8 +280,8 @@ export const Intents = () => {
           <Text as="h2" size="text-hero-m" color="white">
             Explore NEAR Intents
           </Text>
-          <Text size="text-2xl" weight={400} color="white" >
-           Try cross-chain dApps, wallets, and more that are leveraging NEAR Intents.
+          <Text size="text-2xl" weight={400} color="white">
+            Try cross-chain dApps, wallets, and more that are leveraging NEAR Intents.
           </Text>
         </Flex>
 
@@ -317,12 +298,7 @@ export const Intents = () => {
               key={item.url}
               style={{ borderRadius: '25px' } as React.CSSProperties}
             >
-              <Image 
-                      src={item.icon}
-                      alt="Article icon"
-                      width={100}
-                      height={100} 
-                      />
+              <Image src={item.icon} alt="Article icon" width={100} height={100} />
 
               <Flex stack>
                 <Text size="text-l" weight="500">
@@ -338,7 +314,7 @@ export const Intents = () => {
             Getting Started
           </Text>
           <Text size="text-2xl" weight={400} color="white" style={{ maxWidth: '808px' }}>
-          Everything you need to start building with NEAR Intents.
+            Everything you need to start building with NEAR Intents.
           </Text>
         </Flex>
         <Grid
@@ -346,12 +322,12 @@ export const Intents = () => {
           columnsTablet="1fr"
           columnsPhone="1fr"
           gap="l"
-          style={{ 
+          style={{
             marginTop: '-80px',
             maxWidth: '1000px',
             margin: '-80px auto 0',
             justifyContent: 'center',
-            width: '100%'
+            width: '100%',
           }}
         >
           <Card
@@ -362,12 +338,12 @@ export const Intents = () => {
             href="https://docs.near.org"
             target="_blank"
             rel="noopener noreferrer"
-            style={{ 
+            style={{
               width: '100%',
               maxWidth: '600px',
               display: 'flex',
               alignItems: 'center',
-              justifyContent: 'center'
+              justifyContent: 'center',
             }}
           >
             <Flex gap="m" align="center">
@@ -386,12 +362,12 @@ export const Intents = () => {
             href="https://t.me/+RXYjlPob_XM5N2Ex"
             target="_blank"
             rel="noopener noreferrer"
-            style={{ 
+            style={{
               width: '100%',
               maxWidth: '600px',
               display: 'flex',
               alignItems: 'center',
-              justifyContent: 'center'
+              justifyContent: 'center',
             }}
           >
             <Flex gap="m" align="center">
@@ -403,54 +379,44 @@ export const Intents = () => {
           </Card>
         </Grid>
       </Section>
-      
 
-
-        <Section gap="2xl" padding="hero" background="green-brand">
-            <Flex stack gap="l">
+      <Section gap="2xl" padding="hero" background="green-brand">
+        <Flex stack gap="l">
           <Text as="h2" size="text-hero-m" color="black">
             Roadmap
           </Text>
-
         </Flex>
-            <Grid columns="1fr 1fr 1fr" columnsTablet="1fr 1fr" columnsPhone="1fr" gap="l">
-            {Roadmap.map((app) => (
-              <Card
-                gap="l"
-                padding="l"
-                border="black"
-                background="green-brand"
-                key={app.name}
-              >
-                <Flex align="center" gap="l">
-                 
-                  <div>
-                    <Text color="black" size="text-l" weight="500">
-                      {app.name}
-                    </Text>
-                  </div>
-                </Flex>
-                <Text color="black" size="text-s">
-                  {app.description}
-                </Text>
-              </Card>
-            ))}
-          </Grid>
-          <Flex gap="l" align="center" justify="space-between">
-            <Text size="text-2xl" weight="500">
-              Upcoming Events
-            </Text>
-            {hasMoreEvents && (
-              <Button
-                href="https://lu.ma/NEAR-community"
-                target="_blank"
-                label="View All"
-                variant="secondary"
-                size="small"
-              />
-            )}
-          </Flex>
-          {otherEvents.length > 0 && (
+        <Grid columns="1fr 1fr 1fr" columnsTablet="1fr 1fr" columnsPhone="1fr" gap="l">
+          {Roadmap.map((app) => (
+            <Card gap="l" padding="l" border="black" background="green-brand" key={app.name}>
+              <Flex align="center" gap="l">
+                <div>
+                  <Text color="black" size="text-l" weight="500">
+                    {app.name}
+                  </Text>
+                </div>
+              </Flex>
+              <Text color="black" size="text-s">
+                {app.description}
+              </Text>
+            </Card>
+          ))}
+        </Grid>
+        <Flex gap="l" align="center" justify="space-between">
+          <Text size="text-2xl" weight="500">
+            Upcoming Events
+          </Text>
+          {hasMoreEvents && (
+            <Button
+              href="https://lu.ma/NEAR-community"
+              target="_blank"
+              label="View All"
+              variant="secondary"
+              size="small"
+            />
+          )}
+        </Flex>
+        {otherEvents.length > 0 && (
           <Grid columns="1fr 1fr 1fr" columnsTablet="1fr 1fr" columnsPhone="1fr" gap="l">
             {otherEvents.map((event) => {
               return (
@@ -485,9 +451,8 @@ export const Intents = () => {
               );
             })}
           </Grid>
-          )}
-        </Section>
-    
+        )}
+      </Section>
     </>
   );
 };

--- a/src/pages/blog/[[...pages]].tsx
+++ b/src/pages/blog/[[...pages]].tsx
@@ -5,27 +5,43 @@ import { useDefaultLayout } from '@/hooks/useLayout';
 import type { NextPageWithLayout } from '@/utils/types';
 
 export const getServerSideProps = (async ({ resolvedUrl }) => {
-  const blogParts = resolvedUrl.split('blog/');
-  const blog_branch = 'https://near.org' === process.env.NEXT_PUBLIC_HOSTNAME ? 'main' : 'develop';
-  let title = 'index.html';
-  if (blogParts[1] !== title) {
-    title = `${blogParts[1].substring(0, blogParts[1].indexOf('/'))}/index.html`;
-  }
-  const res = await fetch(
-    `https://raw.githubusercontent.com/near/nearorg_marketing/${blog_branch}/public/blog/${title}`,
-  ).catch((e) => {
+  const remoteUrl = `https://pages.near.org${resolvedUrl}`;
+  const res = await fetch(remoteUrl).catch((e) => {
     throw e;
   });
 
-  const __html = await (await res.blob()).text();
+  const html = await (await res.blob()).text();
 
-  return { props: { bloghtml: { __html } } };
+  const replacedHtml = replaceAll(html);
+
+  return { props: { bloghtml: { __html: replacedHtml } } };
 }) satisfies GetServerSideProps<{ bloghtml: any }>;
+
+function searchAndReplace(content: string, searchString: string, replacementString: string): string {
+  const regex = new RegExp(searchString, 'g');
+  return content.replace(regex, replacementString);
+}
+
+function replaceAll(bloghtml: string): string {
+  bloghtml = searchAndReplace(bloghtml, '\\/wp\\-content', 'https://pages.near.org/wp-content');
+  bloghtml = searchAndReplace(bloghtml, 'https:\\/\\/pages\\.near\\.org\\/', '/');
+  bloghtml = searchAndReplace(bloghtml, '="\\/wp\\-content', '="https://pages.near.org/wp-content');
+  bloghtml = searchAndReplace(bloghtml, '="\\/wp\\-includes', '="https://pages.near.org/wp-includes');
+  bloghtml = searchAndReplace(bloghtml, '\\?paged=', 'page/');
+  bloghtml = searchAndReplace(
+    bloghtml,
+    '=https:\\/\\/s3\\-eu\\-west\\-2\\.amazonaws\\.com\\/lawcom\\-prod\\-storage\\-11jsxou24uy7q\\/uploads\\/2022\\/07\\/Digital\\-Assets\\-Consultation\\-Paper\\-Law\\-Commission\\-1\\.pdf',
+    '',
+  );
+
+  return bloghtml;
+}
 
 const StaticBlogPage: NextPageWithLayout = (props) => {
   const onBlogLinkClick = useCallback((event: any) => {
     const url = event.target.href;
     if (url) {
+      // keeps /blog links from opening in a new window
       event.preventDefault();
       window.location = url;
     }
@@ -34,12 +50,24 @@ const StaticBlogPage: NextPageWithLayout = (props) => {
   useEffect(() => {
     //this query fetches almost all links, except the clickable elements that are children of a tags
     // like document.querySelectorAll("h3[class^='headline_type-4']")
-    document.querySelectorAll("a[href^='/blog").forEach((element) => {
+    document.querySelectorAll("a[href^='/blog']").forEach((element) => {
       element.addEventListener('click', onBlogLinkClick);
     });
 
+    // Remove the footer element
+    const footerElement = document.querySelector('.gateway-page-container .near-global-footer');
+    if (footerElement) {
+      footerElement.remove();
+    }
+
+    // Remove the top nav element (only shows up on `/blog/tag/*` pages)
+    const topNavElement = document.querySelector('.gateway-page-container nr-subnav');
+    if (topNavElement) {
+      topNavElement.remove();
+    }
+
     return () => {
-      document.querySelectorAll("a[href^='/blog").forEach((element) => {
+      document.querySelectorAll("a[href^='/blog']").forEach((element) => {
         element.removeEventListener('click', onBlogLinkClick);
       });
     };


### PR DESCRIPTION
Currently the blog publishing process is documented at https://github.com/near/nearorg_wordpress_marketing:
1. Export the pages.near.org content using the Simply Static plugin (30-45 minutes)
2. Commit the HTML files it to the https://github.com/near/nearorg_wordpress_marketing repo.
3. A Github Action does a few regex search-and-replaces on the content.
4. Merge it to the `main` branch.
5. Redeploy the nearorg Vercel/NextJS app.
6. The NextJS app reverse-proxies the content from the raw.githubusercontent.com host.

Seems like more steps than we need.  This change keeps the reverse proxy mechanism, but:
1. Pulls the content directly from pages.near.org instead of GitHub
2. Does the search-and-replaces as necessary on the server side.
3. Also removes the outdated header and footer content.

So now all you need to do to publish a new blog post is redeploy the latest build at https://vercel.com/near-developer-console/nearorg-container/deployments?environment=production.

Also a few other files were failing the linters so I fixed those.